### PR TITLE
V1.1.2 Release

### DIFF
--- a/mule/features/transform_features/embedding_feature.py
+++ b/mule/features/transform_features/embedding_feature.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2021 Pandora Media, LLC.
+# Copyright 2024 Pandora Media, LLC.
 #
 # Licensed under the GNU GPL License, Version 3.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mule/features/transform_features/embedding_feature.py
+++ b/mule/features/transform_features/embedding_feature.py
@@ -25,6 +25,9 @@ from scooch import Param
 
 # Local imports
 from .transform_feature import TransformFeature
+from ...models.layers import WeightStandardization
+from ...models.layers import StochDepth
+from ...models.layers import ScalarMultiply
 
 
 class EmbeddingFeature(TransformFeature):
@@ -99,4 +102,11 @@ class EmbeddingFeature(TransformFeature):
             # TODO [matt.c.mccallum 11.21.22]: Write google storage download code here.
             pass
         # Otherwise assume local
-        self._model = tf.keras.models.load_model(self._model_location, compile=False)
+        custom_objects_dict = {
+            cls.__name__: cls for cls in [
+                WeightStandardization,
+                StochDepth,
+                ScalarMultiply
+            ]
+        }
+        self._model = tf.keras.models.load_model(self._model_location, custom_objects=custom_objects_dict, compile=False)

--- a/mule/models/layers/__init__.py
+++ b/mule/models/layers/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2021 Pandora Media, LLC.
+# Copyright 2024 Pandora Media, LLC.
 #
 # Licensed under the GNU GPL License, Version 3.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mule/models/layers/__init__.py
+++ b/mule/models/layers/__init__.py
@@ -17,3 +17,4 @@
 from .weight_standardization import WeightStandardization
 from .scalar_multiply import ScalarMultiply
 from .stoch_depth import StochDepth
+from .activations import *

--- a/mule/models/sfnfnetf0.py
+++ b/mule/models/sfnfnetf0.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2021 Pandora Media, LLC.
+# Copyright 2024 Pandora Media, LLC.
 #
 # Licensed under the GNU GPL License, Version 3.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mule/models/sfnfnetf0.py
+++ b/mule/models/sfnfnetf0.py
@@ -26,6 +26,7 @@ from scooch import Param
 from .layers import WeightStandardization
 from .layers import ScalarMultiply
 from .layers import StochDepth
+from .layers import get_scaled_activation
 from .model import Model
 
 
@@ -353,7 +354,7 @@ class SfNfNetF0(Model):
             tf.keras.layers.GlobalAveragePooling2D(),   # Slow path
             tf.keras.layers.GlobalAveragePooling2D(),   # Fast path
             tf.keras.layers.Concatenate(),
-            tf.keras.layers.Activation(_scaled_activation(self._scaled_activation_type))
+            tf.keras.layers.Activation(get_scaled_activation(self._scaled_activation_type))
         ]
 
         #
@@ -428,7 +429,7 @@ class SfNfNetF0(Model):
         Return:
             <list(tf.keras.layers.Layer)> - The constructed layers for the stem module.
         """
-        activations = [_scaled_activation(self._scaled_activation_type)]*(len(kernels)-1) + [None]
+        activations = [get_scaled_activation(self._scaled_activation_type)]*(len(kernels)-1) + [None]
         layers = [
             self.get_conv(
                 channels=c,
@@ -588,14 +589,14 @@ class SfNfNetF0(Model):
         #
         if is_transition_block:
             input_layers = [
-                tf.keras.layers.Activation(_scaled_activation(self._scaled_activation_type)),
+                tf.keras.layers.Activation(get_scaled_activation(self._scaled_activation_type)),
                 ScalarMultiply(beta)
             ]
             residual_path = []
         else:
             input_layers = []
             residual_path = [
-                tf.keras.layers.Activation(_scaled_activation(self._scaled_activation_type)),
+                tf.keras.layers.Activation(get_scaled_activation(self._scaled_activation_type)),
                 ScalarMultiply(beta)
             ]
 
@@ -605,7 +606,7 @@ class SfNfNetF0(Model):
         strides = [[1,1], [freq_downsample,1], [1,1], [1,1]] # NOTE [matt.c.mccallum 03.11.22]: Should this frequency downsample be on the frequency convolution layer, or the first (time convoluation) layer? The original NFNet paper talks about striding on the first 3 x 3 conv layer, but in this case, freq convs don't happen until the second non-1x1 conv layer.
         per_layer_out_chans = [output_channels//2]*3 + [output_channels]
         groups = [1] + [output_channels//2//group_size]*2 + [1]
-        activations = [_scaled_activation(self._scaled_activation_type)]*(len(kernels)-1) + [None]
+        activations = [get_scaled_activation(self._scaled_activation_type)]*(len(kernels)-1) + [None]
         residual_path += list(itertools.chain(*[
             self.get_conv(
                 channels=c,

--- a/setup.py
+++ b/setup.py
@@ -60,32 +60,18 @@ For more information on this module, please check out the publication:
 """
 
 
-# Tensorflow on ARM processors (i.e., macbooks with M1 or M2 or newer processors)
-# need a different compilation of tensorflow.
-# More details on the correct combinations of tensorflow packages below can be 
-# found here:
-#   https://developer.apple.com/metal/tensorflow-plugin/
-REQUIRED_TF = []
-if platform.processor()=='arm':
-    REQUIRED_TF += [
-        'tensorflow-macos==2.9.1',
-        'tensorflow-metal==0.5.0'
-    ]
-else:
-    REQUIRED_TF = ['tensorflow==2.9.1']
-
-
 REQUIRED_PACKAGES = [
     'numpy',
     'librosa==0.9.2',
     'click==8.1.7',
-    'scooch>=1.0.4'
-] + REQUIRED_TF
+    'scooch>=1.0.4',
+    'tensorflow==2.13.1'
+]
 
 
 setuptools.setup(
     name='sxmp-mule',
-    version='1.1.1',
+    version='1.1.2',
     description='',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -97,7 +83,6 @@ setuptools.setup(
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering',
@@ -114,7 +99,7 @@ setuptools.setup(
     keywords='mule audio music embeddings machine learning',
 
     install_requires=REQUIRED_PACKAGES,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=setuptools.find_packages(),
     include_package_data=True,
 

--- a/supporting_data/configs/mule_embedding_average.yml
+++ b/supporting_data/configs/mule_embedding_average.yml
@@ -32,7 +32,7 @@ Analysis:                   # The analysis object describes a set of transformat
           BlockExtractor: null
           
     - EmbeddingFeature:     # The EmbeddingFeature takes input features, applies a model and stores the model output as its feature data.
-        model_location: "./supporting_data/model/"
+        model_location: "./supporting_data/model/model.keras"
         extractor:
           SliceExtractor:   # The SliceExtractor extracts slices of feature data from the input feature at regular intervals
             look_forward: 150

--- a/supporting_data/configs/mule_embedding_timeline.yml
+++ b/supporting_data/configs/mule_embedding_timeline.yml
@@ -32,7 +32,7 @@ Analysis:                   # The analysis object describes a set of transformat
           BlockExtractor: null
           
     - EmbeddingFeature:     # The EmbeddingFeature takes input features, applies a model and stores the model output as its feature data.
-        model_location: "./supporting_data/model/"
+        model_location: "./supporting_data/model/model.keras"
         extractor:
           SliceExtractor:   # The SliceExtractor extracts slices of feature data from the input feature at regular intervals
             look_forward: 150

--- a/supporting_data/model/keras_metadata.pb
+++ b/supporting_data/model/keras_metadata.pb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ddf26c6e816354c79b36ea88496e2091791af9ee61073472a3eaafab61c492e3
-size 1005045

--- a/supporting_data/model/model.keras
+++ b/supporting_data/model/model.keras
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1da111d619bac0d422e41f153cbfb903f7ec3c5d3b2768f5d68f04452ed18180
+size 251054764

--- a/supporting_data/model/saved_model.pb
+++ b/supporting_data/model/saved_model.pb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e8c2ba38e17c31b08e2d7d70efcbea41d2b15364479046d54e60d3ac4b7e25c
-size 9133776

--- a/supporting_data/model/variables/variables.data-00000-of-00001
+++ b/supporting_data/model/variables/variables.data-00000-of-00001
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:acd581712ce749a9a96a2284b1a7034a21fd5314b35fd21fa5e467b5aefeaf1e
-size 249742541

--- a/supporting_data/model/variables/variables.index
+++ b/supporting_data/model/variables/variables.index
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e85df1da715637aa2c57509782b52b87ba75da8eef93748b36cd712550797aa9
-size 29124


### PR DESCRIPTION
Update motivated by https://github.com/PandoraMedia/music-audio-representations/issues/1

Changes allow MULE inference to occur on M1/M2/M3 macbooks.

- Updated tensorflow version from 2.9.1 to 2.13.1
- Updated model fromat from .tf to .keras